### PR TITLE
Feat/settings-privacy-admin

### DIFF
--- a/frontend/mms-Admin/src/components/Button/Button.jsx
+++ b/frontend/mms-Admin/src/components/Button/Button.jsx
@@ -47,7 +47,7 @@ function Button(props) {
   return (
     <ButtonComponent size={size} type={type} onClick={onClick} disabled={disabled} className={cx("flexRow")}>
       {loading ? (
-        <img src={imageLoader} height='24' />
+        <img src={imageLoader} height='24' width='60' />
       ) : (
         <>
           <span style={{ marginRight: "0.5rem" }} className={cx("flexRow")}>

--- a/frontend/mms-Admin/src/pages/Dashboard/Settings/Privacy/Privacy.jsx
+++ b/frontend/mms-Admin/src/pages/Dashboard/Settings/Privacy/Privacy.jsx
@@ -5,9 +5,12 @@ import styles from "./Privacy.module.scss";
 import ToggleSwitch from "@/components/ToggleSwitch/ToggleSwitch";
 import { getUserPrivacy, editUserPrivacy } from "@/redux/Settings/SettingsSlice";
 import Loader from "@/components/Loader/Loader";
+import Button from "@/components/Button/Button";
+import { useForm, Controller } from "react-hook-form";
 
 function Privacy() {
   const dispatch = useDispatch();
+  const loading = useSelector((state) => state?.loading?.editUserPrivacyLoading);
   const getUserPrivacyLoading = useSelector((state) => state?.loading?.getUserPrivacyLoading);
   const userPrivacyData = useSelector((state) => state?.settings?.getUserPrivacyData);
   const [userPrivacyArray, setUserPrivacyArray] = useState([]);
@@ -58,34 +61,61 @@ function Privacy() {
     }
   }, [userPrivacyData, getUserPrivacyLoading]);
 
-  const handleEditUserPrivacy = async (status, category) => {
-    const payload = {
-      ...userPrivacyData,
-      [category]: status
-    };
-    let response = await dispatch(editUserPrivacy(payload));
+  const handleEditUserPrivacy = async (data) => {
+    let response = await dispatch(editUserPrivacy(data));
     response?.success && dispatch(getUserPrivacy());
   };
+
+  const {
+    handleSubmit,
+    formState: { errors },
+    control,
+    reset
+  } = useForm({ mode: "all" });
+
+  useEffect(() => {
+    reset(userPrivacyData);
+  }, [reset, userPrivacyData]);
 
   return (
     <div className={cx(styles.privacyContainer, "flexCol")}>
       {Object.keys(userPrivacyData).length === 0 ? (
         <Loader small={false} />
       ) : (
-        Array.isArray(userPrivacyArray) &&
-        userPrivacyArray.map((category) => {
-          return (
-            <div className={cx(styles.infoWrapper, "flexRow-space-between")} key={category?.key}>
-              <h6 className={cx(styles.infoTitle)}>{category.title}</h6>
-              <div className={cx(styles.switchWrapper, "flexRow")}>
-                <ToggleSwitch
-                  checkedStatus={category.value}
-                  onChange={(status) => handleEditUserPrivacy(status, category.key)}
-                />
-              </div>
-            </div>
-          );
-        })
+        <form
+          className={cx(styles.formWrapper, "flexCol")}
+          onSubmit={handleSubmit((data) => handleEditUserPrivacy(data))}
+        >
+          {Array.isArray(userPrivacyArray) &&
+            userPrivacyArray.map((category) => {
+              return (
+                <div className={cx(styles.infoWrapper, "flexRow-space-between")} key={category?.key}>
+                  <h6 className={cx(styles.infoTitle)}>{category.title}</h6>
+                  <div className={cx(styles.switchWrapper, "flexRow")}>
+                    <Controller
+                      name={`${category?.key}`}
+                      control={control}
+                      render={({ field }) => (
+                        <ToggleSwitch
+                          {...field}
+                          error={errors[`${category?.key}`] && errors[`${category?.key}`]?.message}
+                          checkedStatus={category.value}
+                        />
+                      )}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          <div>
+            <Button
+              loading={loading}
+              disabled={loading}
+              onClick={handleSubmit((data) => handleEditUserPrivacy(data))}
+              title='Save Changes'
+            />
+          </div>
+        </form>
       )}
     </div>
   );

--- a/frontend/mms-Admin/src/pages/Dashboard/Settings/Privacy/Privacy.module.scss
+++ b/frontend/mms-Admin/src/pages/Dashboard/Settings/Privacy/Privacy.module.scss
@@ -1,22 +1,24 @@
 .privacyContainer {
-  gap: 2rem;
+  .formWrapper {
+    gap: 2rem;
 
-  .infoWrapper {
-    gap: 1.5rem;
-    align-items: center;
-
-    .infoTitle {
-      font-size: 1rem;
-      margin: 0;
-      padding: 0;
-      font-family: var(--semiBold);
-      color: var(--black2TextColor);
-    }
-
-    .switchWrapper {
-      gap: 2.3rem;
-      padding-right: 0.5rem;
+    .infoWrapper {
+      gap: 1.5rem;
       align-items: center;
+
+      .infoTitle {
+        font-size: 1rem;
+        margin: 0;
+        padding: 0;
+        font-family: var(--semiBold);
+        color: var(--black2TextColor);
+      }
+
+      .switchWrapper {
+        gap: 2.3rem;
+        padding-right: 0.5rem;
+        align-items: center;
+      }
     }
   }
 }

--- a/frontend/mms-Admin/src/redux/api/settings.js
+++ b/frontend/mms-Admin/src/redux/api/settings.js
@@ -17,9 +17,9 @@ export const getUserNotificationsApi = async (data) => {
 };
 
 export const editUserPrivacyApi = async (data) => {
-  return await axios.patch("/UserPrivacy/edituserprivacy", data);
+  return await axios.patch("/UserPrivacy/edit-user-privacy", data);
 };
 
 export const getUserPrivacyApi = async (data) => {
-  return await axios.get("/UserPrivacy/userprivacy", data);
+  return await axios.get("/UserPrivacy/user-privacy", data);
 };


### PR DESCRIPTION
@Honeyloveet , this PR completes the implementation and integration of the privacy submenu under the settings page. The endpoint was adjusted to match the backend update and a save button is now included on the page to optimize performance and ensure that the endpoint is queried only once (when the save button is clicked) instead of calling the update endpoint when each button is toggled.

Kindly review it. Thank you